### PR TITLE
fix live reload by installing node modules on different layer

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,11 +5,12 @@ FROM node:12.11.0-alpine
 RUN mkdir -p /usr/src/backend
 WORKDIR /usr/src/backend
 
+# Install app dependencies
+COPY ./backend/package*.json ./
+RUN npm install
+
 # Bundle app source
 COPY . .
-
-# Install app dependencies
-RUN npm install
 
 # Expose port (will not be respected by Heroku, must be defined in app)
 EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     build: ./frontend
     volumes:
       - ./frontend:/usr/src/frontend
+      - usr/src/frontend/node_modules
     ports:
       - "8080:8080"  
     environment:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,11 +5,12 @@ FROM node:12.11.0-alpine
 RUN mkdir -p /usr/src/frontend
 WORKDIR /usr/src/frontend
 
+# Install app dependencies
+COPY ./frontend/package*.json ./
+RUN npm install
+
 # Bundle app source
 COPY . .
-
-# Install app dependencies
-RUN npm install
 
 # Expose port (will not be respected by Heroku, must be defined in app)
 EXPOSE 8080

--- a/frontend/src/components/HelloWorld.vue
+++ b/frontend/src/components/HelloWorld.vue
@@ -2,7 +2,7 @@
   <div class="hello">
     <h1>{{ msg }}</h1>
     <p>
-      For a tst and recipes on how to configure / customize this project,<br>
+      For a guide and recipes on how to configure / customize this project,<br>
       check out the
       <a href="https://cli.vuejs.org" target="_blank" rel="noopener">vue-cli documentation</a>.
     </p>


### PR DESCRIPTION
# Description

Node Modules were being reloaded on each update to the frontend in the docker image. Fixed by moving node modules to its own layer and volume. Live reload takes reasonable time now. 

## Related PRs

List related PRs against other branches:

| branch          | PR       |
| --------------- | -------- |
| other_pr_description | # |

## Related Issues

List related Issues:

| link |
| ---- |
|  #20 |

## Todos

- [ ] Tests
- [ ] Documentation

## Deploy Notes

Notes regarding deployment the contained body of work. 

## Steps to Test or Reproduce

Outline the steps to test or reproduce the PR here.

```sh
./start.sh
```

## Impacted Areas in Application

List general components of the application that this PR will affect:

- docker-compose
- dev environment
