### PR TITLE
API Token Authentication & Session Management

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,49 +2,30 @@
   <div id="app">
     <img alt="Vue logo" src="./assets/CfB.png" />
     <div id="nav">
-      <router-link v-if="authenticated" to="/login" v-on:click.native="logout()" replace>Logout</router-link>
+      <a href="#" v-if="isAuthenticated()" v-on:click.prevent="logout()">Logout</a>
     </div>
-    <router-view @authenticated="setAuthenticated" />
+    <router-view/>
   </div>
 </template>
 
 <script>
-import { mapState } from "vuex";
-import { mapActions } from "vuex";
-
-export default {
-  name: "App",
-  computed: mapState({
-    auth_token: "auth"
-  }),
-  data() {
-    return {
-      authenticated: false
-    }
-  },
-  mounted() {
-    if(this.$cookies.isKey('Health_Auth')){
-      this.authenticate(this.$cookies.get('Health_Auth'));
-      this.authenticated = true;
-    }
-    if (!this.authenticated) {
-      this.$router.replace({ name: "login" });
-    }else{
-      this.$router.replace({name: 'dashboard'});
-    }
-  },
-  methods: {
-    ...mapActions(["unsetAuth", "authenticate"]),
-    setAuthenticated(status) {
-      this.authenticated = status;
+  export default {
+    name: "App",
+    created() {
+      if(!this.isAuthenticated() && this.$root.getTokenFromCookie()) {
+        this.$root.authenticateUser(this.$root.getTokenFromCookie());
+      }
     },
-    logout() {
-      this.unsetAuth();
-      this.authenticated = false;
-      this.$cookies.remove('Health_Auth');
+    methods: {
+      isAuthenticated() {
+        return this.$root.getAuthenticationStatus();
+      },
+      logout() {
+        this.$root.logout();
+        this.$router.replace({ name: "login" });
+      }
     }
-  }
-};
+  };
 </script>
 
 <style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,27 +2,19 @@
   <div id="app">
     <img alt="Vue logo" src="./assets/CfB.png" />
     <div id="nav">
-      <a href="#" v-if="isAuthenticated()" v-on:click.prevent="logout()">Logout</a>
+      <b-button variant="link" v-if="this.$root.auth_state" v-on:click="logout()">Logout</b-button>
     </div>
-    <router-view/>
+    <router-view></router-view>
   </div>
 </template>
 
 <script>
   export default {
     name: "App",
-    created() {
-      if(!this.isAuthenticated() && this.$root.getTokenFromCookie()) {
-        this.$root.authenticateUser(this.$root.getTokenFromCookie());
-      }
-    },
     methods: {
-      isAuthenticated() {
-        return this.$root.getAuthenticationStatus();
-      },
       logout() {
-        this.$root.logout();
-        this.$router.replace({ name: "login" });
+        this.$root.destroySession();
+        this.$router.push({ name: "login" });
       }
     }
   };

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -46,7 +46,7 @@
     mounted() {
       this.$root.apiRequest("/entity", this.updateEntities);
     }
-  };
+  }
 </script>
 
 <style scoped>

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -1,7 +1,7 @@
 <template>
   <b-container fluid="md" id="secure">
     <h1>Dashboard</h1>
-    <h3>Hello {{this.$jwt.decode(auth_token).email}}</h3>
+    <h3>Hello {{this.$jwt.decode(this.$root.getSavedToken()).email}}</h3>
     <b-row>
       <b-col>
         <!-- Dashboard Table -->
@@ -27,36 +27,23 @@
 </template>
 
 <script>
-import axios from "axios";
-import { mapState } from "vuex";
 
 export default {
   name: "dashboard",
   data() {
     return {
-      api: this.$root.$data.apiEndpoint,
       entities: null
     };
   },
-  computed: mapState({
-    auth_token: "auth"
-  }),
   methods: {
     updateEntities(obj) {
       this.entities = obj;
     }
   },
-  created() {
-    let self = this;
-    axios
-      .get(self.api + "/entity")
-      .then(function(response) {
-        // Save API response to component data
-        self.updateEntities(response.data.results);
-      })
-      .catch(function(err) {
-        console.log(err);
-      });
+  mounted() {
+    this.updateEntities(
+      this.$root.apiRequest("/entity")
+    );
   }
 };
 </script>

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -1,7 +1,7 @@
 <template>
   <b-container fluid="md" id="secure">
     <h1>Dashboard</h1>
-    <h3>Hello {{this.$jwt.decode(this.$root.getSavedToken()).email}}</h3>
+    <h3>Hello {{this.$jwt.decode(this.$root.auth_token).email}}</h3>
     <b-row>
       <b-col>
         <!-- Dashboard Table -->
@@ -31,29 +31,26 @@
 </template>
 
 <script>
-
-export default {
-  name: "dashboard",
-  data() {
-    return {
-      entities: null
-    };
-  },
-  methods: {
-    updateEntities(obj) {
-      this.entities = obj;
+  export default {
+    name: "Dashboard",
+    data() {
+      return {
+        entities: null
+      };
+    },
+    methods: {
+      updateEntities(obj) {
+        this.entities = obj.results;
+      }
+    },
+    mounted() {
+      this.$root.apiRequest("/entity", this.updateEntities);
     }
-  },
-  mounted() {
-    this.updateEntities(
-      this.$root.apiRequest("/entity")
-    );
-  }
-};
+  };
 </script>
 
 <style scoped>
-h1 {
-  text-align: left;
-}
+  h1, h3 {
+    text-align: left;
+  }
 </style>

--- a/src/components/Facility.vue
+++ b/src/components/Facility.vue
@@ -1,6 +1,6 @@
 <template>
     <b-container fluid="md" id="facility">
-        <h1>{{ data.name }}</h1>
+        <h1>{{ entity.name }}</h1>
         <p class="return-link">
             <router-link :to="{ name: 'dashboard'}">&larr; Back to Dashboard</router-link>
         </p>
@@ -8,40 +8,40 @@
             <b-col cols="4">
                 <b-card title="Contact Information">
                     <!-- Show Address if available -->
-                    <h6 class="card-subtitle mb-2" v-if="data.address">Address</h6>
-                    <p v-if="data.address">
-                        <span v-for="line in data.address.street" v-bind:key="line" class="address-line">{{ line }}</span>
-                        <span v-if="data.address.city && data.address.state && data.address.zip" class="address-line">
-                            {{ data.address.city }}, {{ data.address.state }} {{ data.address.zip }}
+                    <h6 class="card-subtitle mb-2" v-if="entity.address">Address</h6>
+                    <p v-if="entity.address">
+                        <span v-for="line in entity.address.street" v-bind:key="line" class="address-line">{{ line }}</span>
+                        <span v-if="entity.address.city && entity.address.state && entity.address.zip" class="address-line">
+                            {{ entity.address.city }}, {{ entity.address.state }} {{ entity.address.zip }}
                         </span>
                     </p>
 
                     <!-- Show Email Address if available -->
-                    <h6 class="card-subtitle mb-2" v-if="data.email">Email Addresses</h6>
-                    <p v-if="data.email" v-bind:class="{ primary: data.email[0].isPrimary }">
-                        <a v-bind:href="'mailto:' +  data.email[0].address">{{ data.email[0].address }}</a>
+                    <h6 class="card-subtitle mb-2" v-if="entity.email">Email Addresses</h6>
+                    <p v-if="entity.email" v-bind:class="{ primary: entity.email[0].isPrimary }">
+                        <a v-bind:href="'mailto:' +  entity.email[0].address">{{ entity.email[0].address }}</a>
                     </p>
-                    <ol v-if="data.email">
-                        <li v-for="address in data.email"
+                    <ol v-if="entity.email">
+                        <li v-for="address in entity.email"
                             v-bind:key="address.address"
                             v-bind:class="{ primary: address.isPrimary }"><a v-bind:href="'mailto:' +  address.address">{{ address.address }}</a></li>
                     </ol>
 
                     <!-- Show Phone Numbers if available -->
-                    <h6 class="card-subtitle mb-2" v-if="data.phone">Phone Numbers</h6>
-                    <p v-if="data.phone" v-bind:class="{ primary: data.phone[0].isPrimary }">
-                        {{ data.phone[0].number }}
+                    <h6 class="card-subtitle mb-2" v-if="entity.phone">Phone Numbers</h6>
+                    <p v-if="entity.phone" v-bind:class="{ primary: entity.phone[0].isPrimary }">
+                        {{ entity.phone[0].number }}
                     </p>
-                    <ol v-if="data.phone">
-                        <li v-for="number in data.phone"
+                    <ol v-if="entity.phone">
+                        <li v-for="number in entity.phone"
                             v-bind:key="number.number"
                             v-bind:class="{ primary: number.isPrimary }">{{ number.number }}</li>
                     </ol>
 
                     <!-- Show Contacts if available -->
-                    <h6 class="card-subtitle mb-2" v-if="data.contacts">Contacts</h6>
-                    <ul v-if="data.contacts">
-                        <li v-for="contact in data.contacts"
+                    <h6 class="card-subtitle mb-2" v-if="entity.contacts">Contacts</h6>
+                    <ul v-if="entity.contacts">
+                        <li v-for="contact in entity.contacts"
                             v-bind:key="contact.id">
                             <a v-bind:href="`/user/${contact.contact.id}`">{{contact.contact.name}}</a><br />
                             Phone:
@@ -86,18 +86,18 @@
         name: "Facility",
         data() {
             return {
-                data: {
-                    name: ""
+                entity: {
+                    name: "Loading..."
                 }
             }
         },
         methods: {
             updateFacilityData(obj) {
-                this.data = obj;
+                this.entity = obj;
             }
         },
-        created() {
-            this.updateFacilityData(this.$root.apiRequest("/entity/" + this.$route.params.entityID));
+        mounted() {
+            this.$root.apiRequest("/entity/" + this.$route.params.entityID, this.updateFacilityData);
         }
     }
 </script>

--- a/src/components/Facility.vue
+++ b/src/components/Facility.vue
@@ -97,7 +97,9 @@
             }
         },
         mounted() {
-            this.$root.apiRequest("/entity/" + this.$route.params.entityID, this.updateFacilityData);
+            if(this.$root.auth_state) {
+                this.$root.apiRequest("/entity/" + this.$route.params.entityID, this.updateFacilityData);
+            }
         }
     }
 </script>

--- a/src/components/Facility.vue
+++ b/src/components/Facility.vue
@@ -82,13 +82,10 @@
 </template>
 
 <script>
-    import axios from 'axios'
-
     export default {
         name: "Facility",
         data() {
             return {
-                api: this.$root.$data.apiEndpoint,
                 data: {
                     name: ""
                 }
@@ -100,15 +97,7 @@
             }
         },
         created() {
-            let self = this;
-            axios
-                .get(self.api + '/entity/' + self.$route.params.entityID)
-                .then(function(response) {
-                    self.updateFacilityData(response.data);
-                })
-                .catch(function(err) {
-                    console.log(err);
-                });
+            this.updateFacilityData(this.$root.apiRequest("/entity/" + this.$route.params.entityID));
         }
     }
 </script>

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -15,7 +15,6 @@
 
 <script>
 import { postLogin } from "../utils/api";
-import { mapActions } from "vuex";
 
 export default {
   name: "Login",
@@ -27,16 +26,21 @@ export default {
       }
     };
   },
+  created() {
+    if(this.$root.getAuthenticationStatus()) {
+      this.$router.replace({ name: "dashboard" });
+    } else if(this.$root.getTokenFromCookie()) {
+      this.$root.authenticateUser(this.$root.getTokenFromCookie());
+      this.$router.replace({ name: "dashboard" });
+    }
+  },
   methods: {
-    ...mapActions(["authenticate"]),
     login() {
       if (this.input.email !== "" && this.input.password !== "") {
         const response = postLogin(this.input.email, this.input.password);
         response.then(data => {
           if (data.data) {
-            this.$cookies.set('Health_Auth', data.data, '1D', true);
-            this.authenticate(data.data);
-            this.$emit("authenticated", true);
+            this.$root.authenticateUser(data.data);
             this.$router.replace({ name: "dashboard" });
           } else {
             // eslint-disable-next-line no-console

--- a/src/main.js
+++ b/src/main.js
@@ -50,13 +50,18 @@ new Vue({
     authenticateUser(response) {
       this.setAuthCookie(response);
       this.authenticate(response);
+      this.$emit("authenticated", true);
     },
     setAuthCookie(response) {
-      if(this.getTokenFromCookie() && !this.getTokenFromCookie().localeCompare(response)){
+      if(this.getTokenFromCookie() && this.getTokenFromCookie() !== response){
+        console.log("cookie looks different.");
         this.$cookies.remove('Health_Auth');
-        this.$cookies.set('Health_Auth', response, '1D', true);
+        this.$cookies.set('Health_Auth', response, '1D', null);
       } else if(!this.getTokenFromCookie()) {
-        this.$cookies.set('Health_Auth', response, '1D', true);
+        console.log("no cookie detected. adding new cookie.");
+        this.$cookies.set('Health_Auth', response, '1D', null);
+      } else {
+        console.log("cookies are the same. doing nothing.");
       }
     },
     getAuthenticationStatus() {
@@ -73,6 +78,7 @@ new Vue({
       this.$cookies.remove('Health_Auth');
     },
     apiRequest(endpoint, callback) {
+      console.log(this.getSavedToken());
       let self = this;
       axios
           .get(self.api + endpoint, {

--- a/src/main.js
+++ b/src/main.js
@@ -7,21 +7,86 @@ import VueCookies from 'vue-cookies';
 import VueJWT from 'vuejs-jwt';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-vue/dist/bootstrap-vue.css';
+import { mapState } from "vuex";
+import { mapActions } from "vuex";
+import axios from "axios";
 
 Vue.use(BootstrapVue);
 Vue.use(VueCookies);
 Vue.use(VueJWT,{storage:'cookie'});
 
-
 Vue.config.productionTip = false;
+
+router.beforeEach((to, from, next) => {
+  if(Vue.$cookies.get('Health_Auth')) {
+    next();
+  } else if (to.name !== 'login' && !store.state.authenticated) {
+    next({name: 'login'});
+  } else {
+    next();
+  }
+});
 
 new Vue({
   store,
   render: h => h(App),
+  computed: mapState({
+    auth_token: "auth"
+  }),
   data(){
     return {
-      apiEndpoint: process.env.VUE_APP_BASE_API_URL
+      api: process.env.VUE_APP_BASE_API_URL,
+      authenticated: false
     }
   },
-  router,
+  methods: {
+    ...mapActions(["unsetAuth", "authenticate"]),
+    authenticateUser(response) {
+      this.authenticated = true;
+      this.setAuthCookie(response);
+      this.authenticate(response);
+      this.$emit("authenticated", true);
+    },
+    setAuthCookie(response) {
+      this.setToken(response);
+      this.$cookies.set('Health_Auth', response, '1D', true);
+    },
+    setToken(token) {
+      store.state.auth = token;
+    },
+    getAuthenticationStatus() {
+      return this.authenticated;
+    },
+    getSavedToken() {
+      return store.state.auth;
+    },
+    getTokenFromCookie() {
+      this.setToken(this.$cookies.get('Health_Auth'));
+      return this.getSavedToken();
+    },
+    logout() {
+      this.authenticated = false;
+      this.unsetAuth();
+      this.$cookies.remove('Health_Auth');
+      this.setToken(null);
+    },
+    apiRequest(endpoint) {
+      let self = this;
+      axios
+          .get(self.api + endpoint, {
+            headers: {
+              'token': self.getSavedToken()
+            },
+          })
+          .then(function(response) {
+            // Save API response to component data
+            return response.data.results;
+          })
+          .catch(function(err) {
+            console.log(err);
+            return false;
+          });
+    },
+  },
+  router
 }).$mount('#app');

--- a/src/router.js
+++ b/src/router.js
@@ -3,7 +3,6 @@ import Router from 'vue-router'
 import LoginComponent from "./components/Login.vue"
 import DashboardComponent from "./components/Dashboard.vue"
 import FacilityComponent from "./components/Facility.vue"
-import HelloWorldComponent from "./components/HelloWorld.vue"
 
 Vue.use(Router);
 
@@ -33,10 +32,8 @@ export default new Router({
             component: FacilityComponent
         },
         {
-            path: "/hello",
-            name: "hello",
-            component: HelloWorldComponent,
-            props: {msg:"Welcome to HealthCare RollCall\nMore to come soon!"}
+            path: '*',
+            redirect: '/dashboard'
         }
     ]
 })

--- a/src/router.js
+++ b/src/router.js
@@ -33,7 +33,7 @@ export default new Router({
         },
         {
             path: '*',
-            redirect: '/dashboard'
+            redirect: '/login'
         }
     ]
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,14 +5,17 @@ Vue.use(Vuex)
 
 export default new Vuex.Store({
   state: {
-    auth: ''
+    auth: '',
+    authenticated: false
   },
   mutations: {
     AUTHENTICATE: (state, token) =>{
       state.auth = token;
+      state.authenticated = true;
     },
     UNSETAUTH: (state) => {
       state.auth = '';
+      state.authenticated = false;
     }
   },
   actions: {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 export const postLogin = (email, password) => {
-    console.log(process.env.VUE_APP_BASE_API_URL)
     const fullUrl = new URL('/user/login', process.env.VUE_APP_BASE_API_URL);
     return axios.post(
         fullUrl.toString(),


### PR DESCRIPTION
# Description

This is to resolve #57.  Ignore the name of the branch.  I tried to rename it, but it didn't work.

This moves code for state and authentication management our of the component and into the root Vue instance.  Additionally, cookies had originally been configured to be recognized only on certain paths.  This was causing the `401` responses and the session randomly terminating after page refresh.  Cookies have been updated to work on all pages on the domain they were originally set on.  This allows the page to be refreshed after authentication and retain the same `token`.

Functionality was added to re-authenticate the user based on the existing session and restore the authenticated state without relying on the `vue-router`.

Finally, a global function was added at the `$root` level to support API queries dynamically.  This function accepts an endpoint and a callback, then injects the token into the header automatically, then returns the response to the callback.

## Related Issues
Resolves #57
Resolves some lingering bugs related to #46


List related Issues:

| link |
| ---- |
|  #57  |
|  #46  |