### PR TITLE
Adding password reset page

### DIFF
--- a/src/components/PasswordReset.vue
+++ b/src/components/PasswordReset.vue
@@ -1,0 +1,86 @@
+<template>
+  <div id="reset">
+    <h1>Password Reset</h1>
+    <form class="reset-container" v-on:submit.prevent>
+      <label>
+        <p> {{ input.email }}</p>
+      </label>
+      <label>
+        <input type="password" name="password" v-model="input.password" placeholder="Password" />
+      </label>
+      <b-button type="submit" v-on:click="resetPass()">Reset Password</b-button>
+    </form>
+    <b-alert
+        :show="this.dismissCountDown"
+        dismissible
+        fade
+        variant="danger"
+        @dismiss-count-down="this.countDownChanged"
+      >{{this.alert_msg}}</b-alert>
+  </div>
+</template>
+
+<script>
+import { updateUser } from "../utils/api";
+
+export default {
+  name: "PasswordReset",
+  data() {
+    return {
+      input: {
+        email: "",
+        password: ""
+      },
+      dismissSecs: 5,
+      dismissCountDown: 0,
+      alert_msg: ""
+    };
+  },
+  mounted() {
+      this.input.email = this.$jwt.decode(this.$route.params.token).email
+  },
+  methods: {
+    resetPass() {
+      if (this.input.email != "" && this.input.password !== "") {
+        const response = updateUser(this.$route.params.token, this.input.email, this.input.password);
+        response
+          .then((data) => {
+              if(data.status == 200){
+                this.$router.replace({ name: "login" });
+              }else{
+                  this.showAlert("Failed updating password");
+              }
+          });
+      }
+    },
+    countDownChanged(dismissCountDown) {
+      this.dismissCountDown = dismissCountDown;
+    },
+    showAlert(msg) {
+      this.alert_msg = msg;
+      this.dismissCountDown = this.dismissSecs;
+    }
+  }
+};
+</script>
+
+<style scoped>
+#reset {
+  width: 500px;
+  background-color: #ffffff;
+  margin: auto;
+  padding: 20px;
+}
+.reset-container {
+  margin: auto;
+  margin-bottom: 1rem;
+  width: 200px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.reset-container > input {
+  margin-bottom: 10px;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,9 @@ Vue.config.productionTip = false;
 router.beforeEach((to, from, next) => {
   if(Vue.$cookies.get('Health_Auth')) {
     next();
-  } else if (to.name !== 'login' && !store.state.authenticated) {
+  } else if(to.name == 'reset' && !store.state.authenticated){
+    next();
+  }else if (to.name !== 'login' && !store.state.authenticated) {
     next({name: 'login'});
   } else {
     next();

--- a/src/router.js
+++ b/src/router.js
@@ -3,6 +3,7 @@ import Router from 'vue-router'
 import LoginComponent from "./components/Login.vue"
 import DashboardComponent from "./components/Dashboard.vue"
 import FacilityComponent from "./components/Facility.vue"
+import PasswordResetComponent from "./components/PasswordReset.vue"
 
 Vue.use(Router);
 
@@ -30,6 +31,11 @@ export default new Router({
             path: '/facility/:entityID',
             name: 'facility',
             component: FacilityComponent
+        },
+        {
+            path: "/reset/:token",
+            name: 'reset',
+            component: PasswordResetComponent
         },
         {
             path: '*',

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -18,3 +18,18 @@ export const postReset = (email) => {
             email
         }).then(response => response)
 };
+
+export const updateUser = (email_token, email, password) => {
+    const fullUrl = new URL('/user', process.env.VUE_APP_BASE_API_URL);
+    return axios.put(fullUrl.toString(),
+        {
+            email,
+            password,
+        },
+        {
+            headers: {
+                'email_token': email_token
+            }
+        }
+    ).then(response => response);
+}


### PR DESCRIPTION
# Description

Adding password reset page. Needs to have updates performed for backend to ensure proper security around password reset. Needs to have a jwt token with the users email set within the token to ensure that the user can only change their own password.

## Related PRs

List related PRs against other branches:

| branch          | PR       |
| --------------- | -------- |
| Adding ability to request password reset email | #62  |

## Related Issues

List related Issues:

| link |
| ---- |
|  #60   |

## Todos

- [ ] Tests
