### PR TITLE
Dashboard Status HOTFIX

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -62,7 +62,7 @@
             >{{ data.item.name }}</router-link>
           </template>
           <template v-slot:cell(status)="data">
-            <span v-if="data.item.checkIn.checkIns.length > 0">{{ data.item.checkIn.checkIns[data.item.checkIn.checkIns.length-1].status }}</span>
+            <span v-if="data.item.checkIn">{{ data.item.checkIn.checkIns[data.item.checkIn.checkIns.length-1].status }}</span>
           </template>
         </b-table>
         <b-pagination


### PR DESCRIPTION
# Description

Change in data structure caused the status column to break when no checkins existed.  This fixes it.

This should resolve all updates, assuming the email address is restored to the JWT token sent from the back end.