### PR TITLE
Contact form updates

### DIFF
--- a/src/components/Contact.vue
+++ b/src/components/Contact.vue
@@ -12,7 +12,7 @@
               type="tel"
               ref="contactPhone"
               v-model="numberFormatted"
-              @keydown.native.prevent="formatTelInput($event)"
+              @keydown.exact="formatTelInput($event)"
               @keydown.delete.prevent="formatTelBackspace($event)"
               minlength="17"
               :state="phoneValid"
@@ -80,22 +80,22 @@ export default {
   methods: {
     updateContact(obj) {
       let tempObj = obj;
-      if (tempObj.phone) {
-        tempObj.phone = [{ address: null, isPrimary: true }];
+      if (!tempObj.phone) {
+        tempObj.phone = [{ number: null, isPrimary: true }];
       }
       if (!tempObj.email) {
         tempObj.email = [{ address: null, isPrimary: true }];
       }
-      this.contact = this.duplicateData(tempObj);
+      this.contact = tempObj;
       if (this.contact.phone) {
         if (
-          this.contact.phone[0].number.length <= 10 &&
-          this.contact.phone[0].number.charAt(0) !== "1"
+            this.contact.phone[0].number.length < 11 ||
+            this.contact.phone[0].number.charAt(0) !== "1"
         ) {
           this.contact.phone[0].number = "1" + this.contact.phone[0].number;
         }
         this.numberFormatted = this.$options.filters.phone(
-          this.contact.phone[0].number
+                this.contact.phone[0].number
         );
       }
     },
@@ -154,6 +154,7 @@ export default {
           ["1", "2", "3", "4", "5", "6", "7", "8", "9", "0"].join("|")
         ).test(event.key)
       ) {
+        event.preventDefault();
         if (this.contact.phone[0].number == null) {
           this.contact.phone[0].number = "1";
         }
@@ -163,7 +164,7 @@ export default {
             this.contact.phone[0].number
           );
         }
-      } else {
+      } else if(event.key !== "Tab") {
         event.preventDefault();
       }
     },

--- a/src/router.js
+++ b/src/router.js
@@ -52,5 +52,8 @@ export default new Router({
             path: '*',
             redirect: '/login'
         }
-    ]
+    ],
+    scrollBehavior () {
+        return { x: 0, y: 0};
+    }
 })


### PR DESCRIPTION
# Description

Fixes a bug where the phone number field would not release focus on `tab`.

Allows better flexibility in regard to country code presence (`+1`).

Fixes a bug where the page scroll state would not reset on `$route` change.

Fixes a bug where the phone number field was not editable when updating a contact.

Fixes a bug where the phone number field was not automatically populated when updating a contact.

Fixes a bug where the `phone.number` variable was not instantiated correctly and resulted in a console error when creating a contact.