### PR TITLE
Bug Fixes for unlinking modal

### DIFF
--- a/src/templates/Contact.vue
+++ b/src/templates/Contact.vue
@@ -94,7 +94,15 @@
 
     <b-modal ref="unlink-entity" title="Unlink Entity" @ok="unlinkContact">
       <div class="d-block text-center">
-        <p>Are you sure you want to unlink this {{ this.selectedContact.name || 'contact' }}?</p>
+        <p>
+          Are you sure you want to unlink
+          {{ this.contact ? this.contact.name : "this contact" }} from
+          {{
+            this.contact.entities.find(entity => entity.id === this.selectedEntityID)
+              ? this.contact.entities.find(entity => entity.id === this.selectedEntityID).name
+              : "this facility"
+          }}?
+        </p>
       </div>
     </b-modal>
 

--- a/src/templates/FacilityEdit.vue
+++ b/src/templates/FacilityEdit.vue
@@ -43,7 +43,7 @@
             entity.contacts.some(contact => contact.id === this.selectedContactID) ? 
               entity.contacts.find(contact => contact.id === this.selectedContactID).name 
               : 'this contact' 
-          }} from {{ this.entity.name | 'this facility' }}?
+          }} from {{ this.entity.name || 'this facility' }}?
         </p>
       </div>
     </b-modal>

--- a/src/templates/FacilityEdit.vue
+++ b/src/templates/FacilityEdit.vue
@@ -37,7 +37,14 @@
 
     <b-modal ref="unlink-entity" title="Unlink Entity" @ok="unlinkEntity">
       <div class="d-block text-center">
-        <p>Are you sure you want to unlink {{ this.selectedContactID || 'facility' }}?</p>
+        <p>
+          Are you sure you want to unlink
+          {{ 
+            entity.contacts.some(contact => contact.id === this.selectedContactID) ? 
+              entity.contacts.find(contact => contact.id === this.selectedContactID).name 
+              : 'this contact' 
+          }} from {{ this.entity.name | 'this facility' }}?
+        </p>
       </div>
     </b-modal>
 


### PR DESCRIPTION
# Description

I fixed a bug where the contact's name was not included in the confirmation modal when unlinking a contact from a facility.

I also added the facility name to the confirmation modal that shows when unlinking a contact, because I thought that would be useful too.

I made this change on both the contacts page (when unlinking a facility) and the facility page (when unlinking the contact).

## Related PRs

N/A

## Related Issues

N/A

## Todos

N/A

## Deploy Notes

Nothing new

## Steps to Test or Reproduce

-Login
-Click a facility's name
-Click a linked contact
-Select any facility in the "unlink" dropdown and press the unlink button
-The contact's name and facility's name should show in the confirmation modal

## Impacted Areas in Application

The contact details page/form
http://localhost:3000/contact/single/[UUID]

The facility edit page
http://localhost:3001/facility/edit/31fdea59-de6d-4cb2-bc97-78f4c2dc826f
