### PR TITLE
UI Improvments for linked items

### DIFF
--- a/src/templates/Contact.vue
+++ b/src/templates/Contact.vue
@@ -102,14 +102,21 @@
       <b-col cols="12" md="6">
         <h4>Linked Facilities</h4>
         <b-input-group v-if="contact.entities.length > 0">
-          <b-form-select v-model="selectedEntityID" :options="entitySelectList"></b-form-select>
-            <b-button
-            type="submit"
-            variant="primary"
-            @click.prevent="showUnlinkModal"
-            class="ml-2"
-            :disabled="!selectedEntityID"
-            >Unlink from Facility</b-button>
+          <ul id="linked-facilities">
+            <li v-for="entity in entitySelectList" :key="entity.value">
+              {{ entity.text }}
+              
+              <b-button
+                type="submit"
+                variant="light"
+                size="sm"
+                v-on:click="showUnlinkModal(entity.value)"
+              >
+              <b-icon-trash></b-icon-trash>
+              <div class='sr-only'>Unlink from Contact</div>
+              </b-button>
+            </li>
+          </ul>
         </b-input-group>
         <p v-if="contact.entities.length === 0">This contact has no linked facilities.</p>
         <br>
@@ -298,7 +305,8 @@ export default {
           this.returnToLastPage
       );
     },
-    showUnlinkModal() {
+    showUnlinkModal(entityID) {
+      this.selectedEntityID = entityID;
       this.$refs['unlink-entity'].show()
     },
     unlinkContact() {

--- a/src/templates/FacilityEdit.vue
+++ b/src/templates/FacilityEdit.vue
@@ -45,14 +45,21 @@
       <b-col cols="12" md="6">
         <h4>Linked Contacts</h4>
         <b-input-group v-if="entity.contacts.length > 0">
-          <b-form-select v-model="selectedContactID" :options="contactSelectList"></b-form-select>
-          <b-button
-            type="submit"
-            variant="primary"
-            class="ml-2"
-            :disabled="!selectedContactID"
-            @click.prevent="showUnlinkModal"
-          >Unlink from Facility</b-button>
+          <ul id="linked-contacts">
+            <li v-for="contact in contactSelectList" :key="contact.value">
+              {{ contact.text }}
+              
+              <b-button
+                type="submit"
+                variant="light"
+                size="sm"
+                v-on:click="showUnlinkModal(contact.value)"
+              >
+              <b-icon-trash></b-icon-trash>
+              <div class='sr-only'>Unlink from Facility</div>
+              </b-button>
+            </li>
+          </ul>
         </b-input-group>
         <p v-if="entity.contacts.length === 0">This facility has no linked contact.</p>
         <br />
@@ -88,7 +95,7 @@ export default {
           contacts: []
         },
         showAdmin,
-        contactSelectList: [{ value: null, text: "Contacts Linked" }],
+        contactSelectList: [],
         selectedContactID: null,
         stateSelected: "MD",
         stateOptions: [{ value: "MD", text: "Maryland" }],
@@ -155,7 +162,8 @@ export default {
     duplicateData(object) {
       return JSON.parse(JSON.stringify(object))
     },
-    showUnlinkModal() {
+    showUnlinkModal(contactID) {
+      this.selectedContactID = contactID;
       this.$refs['unlink-entity'].show()
     },
     unlinkEntity() {


### PR DESCRIPTION
# Description
  - improve UI of linked contacts on the facilities page
  - improve UI of linked facilities on the contacts page

## Related PRs

N/A

## Related Issues

List related Issues:

| link |
| ---- |
|  #209   |

## Todos

N/A

## Deploy Notes

N/A

## Steps to Test or Reproduce
 
- Edit a Facility with linked Contacts
  - The linked contacts section near the bottom of the screen should be a bulleted list of contacts
  - Each contact should have a trashcan button to the right of their name
  - If the trashcan button is clicked, a confirm modal should appear
    - If the confirm modal is closed or cancelled, the modal should close with no changes
    - If the OK button is clicked, the contact should become unlinked.

- Edit a Contact with linked Facilities
  - The linked facilities section near the bottom of the screen should be a bulleted list of facilities
  - Each facility should have a trashcan button to the right of it's name
  - If the trashcan button is clicked, a confirm modal should appear
    - If the confirm modal is closed or cancelled, the modal should close with no changes
    - If the OK button is clicked, the facility should become unlinked.

## Impacted Areas in Application

Edit Facility -> Linked Contact
Edit Contact -> Linked Facilities
