### PR TITLE
getting facility types from backend

### DIFF
--- a/src/constants/facilities.const.js
+++ b/src/constants/facilities.const.js
@@ -1,3 +1,0 @@
-export const FACILITY_TYPES = [
-    "Assisted Living Facility", "Mixed Housing", "Senior Housing"
-];

--- a/src/templates/Dashboard.vue
+++ b/src/templates/Dashboard.vue
@@ -120,7 +120,6 @@
 </template>
 
 <script>
-import {FACILITY_TYPES} from '../constants/facilities.const';
 
 export default {
   name: "Dashboard",
@@ -129,7 +128,6 @@ export default {
         this.$jwt.decode(this.$root.auth_token).type === "admin" ? true : false
     const showUser =
         this.$jwt.decode(this.$root.auth_token).type === "user" ? true : false
-
     return {
       rows: 0,
       perPage: 25,
@@ -143,7 +141,7 @@ export default {
       statusOptions: [],
       showAdmin,
       showUser,
-      facilityTypes: FACILITY_TYPES,
+      facilityTypes: [],
       facilityTypeSelected: null,
       showEmailErr: false,
       entities: null,
@@ -173,6 +171,7 @@ export default {
           entity.status = "No Previous Check-in"
         }
       }
+      this.$root.apiGETRequest("/facilitytype", this.populateFacilityTypes)
     },
     sendEmail() {
       // send emails
@@ -254,14 +253,20 @@ export default {
       document.body.appendChild(link);
       link.click();
       link.remove();
-    }
+    },
+    populateFacilityTypes(facilityTypes) {
+      this.facilityTypes = facilityTypes
+    },
   },
   mounted() {
+    console.log("MOUNTING")
     let options = this.$root.getStatuses().map(status => {
       return {value: status, text: status, disabled: false}
     })
     this.statusOptions = [{value: null, text: "All"}, ...options]
+    console.log("UPDATING ENTITIES")
     this.$root.apiGETRequest("/entity", this.updateEntities)
+    console.log("MOUNTED")
   }
 }
 </script>

--- a/src/templates/Dashboard.vue
+++ b/src/templates/Dashboard.vue
@@ -259,14 +259,11 @@ export default {
     },
   },
   mounted() {
-    console.log("MOUNTING")
     let options = this.$root.getStatuses().map(status => {
       return {value: status, text: status, disabled: false}
     })
     this.statusOptions = [{value: null, text: "All"}, ...options]
-    console.log("UPDATING ENTITIES")
     this.$root.apiGETRequest("/entity", this.updateEntities)
-    console.log("MOUNTED")
   }
 }
 </script>

--- a/src/templates/FacilityEdit.vue
+++ b/src/templates/FacilityEdit.vue
@@ -107,15 +107,7 @@ export default {
         stateSelected: "MD",
         stateOptions: [{ value: "MD", text: "Maryland" }],
         typeSelected: null,
-        typeOptions: [
-          { value: null, text: "Select facility type" },
-          {
-            value: "Assisted Living Facility",
-            text: "Assisted Living Facility"
-          },
-          { value: "Mixed Housing", text: "Mixed Housing" },
-          { value: "Senior Housing", text: "Senior Housing" }
-        ]
+        typeOptions: []
       }
     )
   },
@@ -140,6 +132,12 @@ export default {
           value: contact_.id,
           text: contact_.name
         })
+      }
+    },
+    populateFacilityTypesDropdown(facilityTypes) {
+      this.typeOptions.push({value: null, text: "Select facility type"})
+      for (let type_ of facilityTypes) {
+        this.typeOptions.push({value: type_, text: type_})
       }
     },
     returnToLastPage() {
@@ -197,6 +195,7 @@ export default {
     }
   },
   mounted() {
+    this.$root.apiGETRequest("/facilitytype", this.populateFacilityTypesDropdown)
     if (this.$route.params.entityID) {
       this.getEntity(this.$route.params.entityID)
     }


### PR DESCRIPTION
# Description

Getting facility types from backend instead of managing facility types in front end.

## Related PRs

List related PRs against other branches:

https://github.com/CodeForBaltimore/Bmore-Responsive/pull/322


## Steps to Test or Reproduce

Run front end. Should see calls to backend for facility types when either:
- editing existing entity
- adding new entity
- clicking `email facilities` on dashboard

## Impacted Areas in Application
- list of facility types in email facilities modal
- types dropdown in edit/add facility form
