### PR TITLE
updated port mapping for backend

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
     depends_on:
       - db
     ports:
-      - ${API_PORT:-3001}:3000
+      - ${API_PORT:-3001}:3001
     expose:
       - ${API_PORT:-3001}
     command: >


### PR DESCRIPTION
# Description

After building both backend and frontend apps using docker compose, I was not able to access the backend app. Updated the port mapping for the backend api in the docker-compose.yaml file to resolve the issue.

## Steps to Test or Reproduce

- Build both backend and frontend apps with docker compose by running the command below
```sh
docker-compose up -d --build
```
- Log into the frontend and confirm you're able to get to the home page.

## Impacted Areas in Application

List general components of the application that this PR will affect:

- docker-compose.yaml
