### PR TITLE
Adding logic to show different submission follow-up options for provi…

### DIFF
--- a/src/components/covidForm.vue
+++ b/src/components/covidForm.vue
@@ -297,7 +297,7 @@
           v-model="newCheckIn.status"
           name="question-status"
           value="Spoke to owner. Follow-up needed."
-        >Yes, Follow-up needed.</b-form-radio>
+        >Yes, follow-up needed.</b-form-radio>
       </b-form-group>
       <b-button type="submit" variant="primary">Submit Check-In</b-button>
       <b-button type="reset" variant="outline-secondary">Reset</b-button>
@@ -318,9 +318,7 @@ export default {
   data() {
     const validRoles = ["admin", "user"];
     const showDetails =
-      validRoles.indexOf(this.$jwt.decode(this.$root.auth_token).type) > -1
-        ? true
-        : false;
+      validRoles.indexOf(this.$jwt.decode(this.$root.auth_token).type);
     return {
       formName: "COVID-19 Response",
       elementFocus: null,

--- a/src/components/covidForm.vue
+++ b/src/components/covidForm.vue
@@ -228,8 +228,9 @@
           rows="3"
         ></b-form-textarea>
       </b-form-group>
-      <h5>Call Outcome &amp; Follow-up</h5>
-      <b-form-group
+
+      <h5 v-if="showDetails">Call Outcome &amp; Follow-up</h5>
+      <b-form-group v-if="showDetails"
         id="check-in-input-status"
         label="Choose an outcome and indicate if a follow-up is needed"
       >
@@ -278,6 +279,26 @@
           value="Wrong number"
         >Wrong Number</b-form-radio>
       </b-form-group>
+
+
+      <h5 v-if="!showDetails">Follow-up</h5>
+      <b-form-group v-if="!showDetails"
+        id="check-in-input-status"
+        label="Do you need us to follow up with you?"
+      >
+        <b-form-radio
+          required
+          v-model="newCheckIn.status"
+          name="question-status"
+          value="Spoke to owner. No follow-up needed."
+        >No follow-up needed.</b-form-radio>
+        <b-form-radio
+          required
+          v-model="newCheckIn.status"
+          name="question-status"
+          value="Spoke to owner. Follow-up needed."
+        >Yes, Follow-up needed.</b-form-radio>
+      </b-form-group>
       <b-button type="submit" variant="primary">Submit Check-In</b-button>
       <b-button type="reset" variant="outline-secondary">Reset</b-button>
     </b-form>
@@ -295,6 +316,11 @@ export default {
   name: "covidForm",
   props: ["entity", "entityCheckIn"],
   data() {
+    const validRoles = ["admin", "user"];
+    const showDetails =
+      validRoles.indexOf(this.$jwt.decode(this.$root.auth_token).type) > -1
+        ? true
+        : false;
     return {
       formName: "COVID-19 Response",
       elementFocus: null,
@@ -374,7 +400,8 @@ export default {
           value: null
         }
       },
-      showForm: true
+      showForm: true,
+      showDetails
     };
   },
   methods: {

--- a/src/components/covidForm.vue
+++ b/src/components/covidForm.vue
@@ -318,7 +318,7 @@ export default {
   data() {
     const validRoles = ["admin", "user"];
     const showDetails =
-      validRoles.indexOf(this.$jwt.decode(this.$root.auth_token).type);
+      validRoles.indexOf(this.$jwt.decode(this.$root.auth_token).type) > -1;
     return {
       formName: "COVID-19 Response",
       elementFocus: null,

--- a/src/templates/Facility.vue
+++ b/src/templates/Facility.vue
@@ -225,7 +225,7 @@ export default {
   data() {
     const validRoles = ["admin", "user"];
     const showDetails =
-      validRoles.indexOf(this.$jwt.decode(this.$root.auth_token).type);
+      validRoles.indexOf(this.$jwt.decode(this.$root.auth_token).type) > -1;
     return {
       historyFields: [
         {

--- a/src/templates/Facility.vue
+++ b/src/templates/Facility.vue
@@ -225,9 +225,7 @@ export default {
   data() {
     const validRoles = ["admin", "user"];
     const showDetails =
-      validRoles.indexOf(this.$jwt.decode(this.$root.auth_token).type) > -1
-        ? true
-        : false;
+      validRoles.indexOf(this.$jwt.decode(this.$root.auth_token).type);
     return {
       historyFields: [
         {


### PR DESCRIPTION
When a provider or owner checks-in via email link they are given different outcome options that are more relevant to them.

## Related Issues

List related Issues:

| link |
| ---- |
|  #226  |

## Todos

- [ ] Tests
- [ ] Documentation

## Impacted Areas in Application

List general components of the application that this PR will affect:

- Provider-direct check-in form.
