### PR TITLE
Account Management page created

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,8 +3,8 @@
     <b-navbar variant="faded" type="dark" id="primary-nav">
       <b-container fluid="md">
         <b-navbar-brand v-on:click="goToDashboard()" role="link" class="branding-link">
-          <img alt="City of Baltimore Seal" src="./assets/balt-logo-white.png" class="seal"/>
-          <img alt="Healthcare Roll Call" src="./assets/hcrc.svg" class="app-logo"/>
+          <img alt="City of Baltimore Seal" src="./assets/balt-logo-white.png" class="seal" />
+          <img alt="Healthcare Roll Call" src="./assets/hcrc.svg" class="app-logo" />
         </b-navbar-brand>
       </b-container>
     </b-navbar>
@@ -13,10 +13,7 @@
         <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
         <b-collapse id="nav-collapse" is-nav>
           <b-navbar-nav>
-            <b-nav-item
-                v-on:click="goToDashboard()"
-                v-if="checkNavBar && showDashboardLink()"
-            >
+            <b-nav-item v-on:click="goToDashboard()" v-if="checkNavBar && showDashboardLink()">
               <span class="d-none d-md-block">
                 <b-icon-arrow-left-circle class="mr-1"></b-icon-arrow-left-circle>
                 Return to Dashboard
@@ -31,6 +28,7 @@
               <!-- Using 'button-content' slot -->
               <template v-slot:button-content>Management</template>
               <b-dropdown-item v-on:click="goToContacts()">Contacts</b-dropdown-item>
+              <b-dropdown-item @click="goToAccountManager">Account</b-dropdown-item>
             </b-nav-item-dropdown>
             <b-nav-item-dropdown right>
               <!-- Using 'button-content' slot -->
@@ -46,16 +44,13 @@
     </b-navbar>
     <router-view></router-view>
     <b-container fluid="md" id="footer">
-      <img alt="Code for Baltimore Logo" src="./assets/CfB.png" width="200"/>
-      <br/>
+      <img alt="Code for Baltimore Logo" src="./assets/CfB.png" width="200" />
+      <br />
       <strong>
         Proudly Designed &amp; Developed by
-        <a
-            href="https://codeforbaltimore.org/"
-            target="_blank"
-        >Code for Baltimore</a>
+        <a href="https://codeforbaltimore.org/" target="_blank">Code for Baltimore</a>
       </strong>
-      <br/>A local chapter of
+      <br />A local chapter of
       <a href="https://www.codeforamerica.org/" target="_blank">Code for America</a>
     </b-container>
   </div>
@@ -66,34 +61,26 @@ export default {
   name: "App",
   data() {
     const navBar = this.$root.getNavBarStatus();
-    const user = this.$root.auth_token
-        ? this.$jwt.decode(this.$root.auth_token).email
-        : false;
-    const role = this.$jwt.decode(this.$root.auth_token).type || '';
+    const user = this.$root.auth_token ? this.$jwt.decode(this.$root.auth_token).email : false;
+    const role = this.$jwt.decode(this.$root.auth_token).type || "";
     return {
       user,
       navBar,
       role,
-      disableBackBtn: [
-        "dashboard",
-        "link-contact",
-        "create-contact",
-        "update-contact",
-        "facility"
-      ]
+      disableBackBtn: ["dashboard", "link-contact", "create-contact", "update-contact", "facility"],
     };
   },
   methods: {
     logout() {
       this.$root.destroySession();
-      this.$router.push({name: "login"});
+      this.$router.push({ name: "login" });
     },
     goBack() {
       this.$router.go(-1);
     },
     goToDashboard() {
       if (this.$router.currentRoute.name !== "dashboard") {
-        this.$router.push({name: "dashboard"});
+        this.$router.push({ name: "dashboard" });
       }
     },
     showDashboardLink() {
@@ -109,24 +96,29 @@ export default {
     },
     goToContacts() {
       if (this.$router.currentRoute.name !== "get-all-contacts") {
-        this.$router.push({name: "get-all-contacts"});
+        this.$router.push({ name: "get-all-contacts" });
+      }
+    },
+    goToAccountManager() {
+      if (this.$router.currentRoute.name !== "account-manager") {
+        this.$router.push({ name: "account-manager" });
       }
     },
     updateUser() {
-      if (this.$root.auth_token) this.user = this.$jwt.decode(this.$root.auth_token).email
-    }
+      if (this.$root.auth_token) this.user = this.$jwt.decode(this.$root.auth_token).email;
+    },
   },
   computed: {
     checkNavBar() {
-      this.updateUser()
+      this.updateUser();
       return this.$root.getNavBarStatus();
-    }
-  }
+    },
+  },
 };
 </script>
 
 <style src="vue-multiselect/dist/vue-multiselect.min.css"></style>
 
 <style lang="scss">
-@import 'src/assets/styles/main';
+@import "src/assets/styles/main";
 </style>

--- a/src/router.js
+++ b/src/router.js
@@ -1,91 +1,97 @@
-import CheckInRedirect from "./templates/CheckInRedirect.vue"
-import ContactComponent from "./templates/Contact.vue"
-import ContactListComponent from "./templates/ContactList.vue"
-import DashboardComponent from "./templates/Dashboard.vue"
-import FacilityComponent from "./templates/Facility.vue"
-import FacilityEditComponent from "./templates/FacilityEdit.vue"
-import LoginComponent from "./templates/Login.vue"
-import PasswordResetComponent from "./templates/PasswordReset.vue"
-import Router from 'vue-router'
-import Vue from 'vue'
+import CheckInRedirect from "./templates/CheckInRedirect.vue";
+import ContactComponent from "./templates/Contact.vue";
+import ContactListComponent from "./templates/ContactList.vue";
+import DashboardComponent from "./templates/Dashboard.vue";
+import FacilityComponent from "./templates/Facility.vue";
+import FacilityEditComponent from "./templates/FacilityEdit.vue";
+import LoginComponent from "./templates/Login.vue";
+import PasswordResetComponent from "./templates/PasswordReset.vue";
+import AccountManagerComponent from "./templates/AccountManager.vue";
+import Router from "vue-router";
+import Vue from "vue";
 
 Vue.use(Router);
 
 export default new Router({
-    mode: 'history',
-    routes: [
-        {
-            path: '/',
-            redirect: {
-                name: "login"
-            }
-        },
-        {
-            path: "/login",
-            name: "login",
-            component: LoginComponent
-        },
-        {
-            path: "/dashboard",
-            name: "dashboard",
-            component: DashboardComponent
-        },
-        {
-            path: '/facility/:entityID',
-            name: 'facility',
-            component: FacilityComponent
-        },
-        {
-            path: '/facility/edit/:entityID',
-            name: 'facility-edit',
-            component: FacilityEditComponent
-        },
-        {
-            path: '/facility/add',
-            name: 'facility-add',
-            component: FacilityEditComponent
-        },
-        {
-            path: "/reset/:token",
-            name: 'reset',
-            component: PasswordResetComponent
-        },
-        {
-            path: "/contact/link/new/:entityID",
-            name: 'link-contact',
-            component: ContactComponent
-        },
-        {
-            path: "/contact/new/",
-            name: 'create-contact',
-            component: ContactComponent
-        },
-        {
-            path: "/contact/link/update/:entityID/:contactID",
-            name: 'update-contact',
-            component: ContactComponent
-        },
-        {
-            path: "/contact/all",
-            name: 'get-all-contacts',
-            component: ContactListComponent
-        },
-        {
-            path: "/contact/single/:contactID",
-            name: 'get-single-contact',
-            component: ContactComponent
-        },
-        {
-            path: "/checkin/:entityId",
-            name: 'checkin',
-            component: CheckInRedirect
-        },
-        {
-            path: '*',
-            redirect: '/login'
-        }
-    ],
-    scrollBehavior() {
-        return { x: 0, y: 0 };
-    }
-})
+  mode: "history",
+  routes: [
+    {
+      path: "/",
+      redirect: {
+        name: "login",
+      },
+    },
+    {
+      path: "/login",
+      name: "login",
+      component: LoginComponent,
+    },
+    {
+      path: "/dashboard",
+      name: "dashboard",
+      component: DashboardComponent,
+    },
+    {
+      path: "/facility/:entityID",
+      name: "facility",
+      component: FacilityComponent,
+    },
+    {
+      path: "/facility/edit/:entityID",
+      name: "facility-edit",
+      component: FacilityEditComponent,
+    },
+    {
+      path: "/facility/add",
+      name: "facility-add",
+      component: FacilityEditComponent,
+    },
+    {
+      path: "/reset/:token",
+      name: "reset",
+      component: PasswordResetComponent,
+    },
+    {
+      path: "/contact/link/new/:entityID",
+      name: "link-contact",
+      component: ContactComponent,
+    },
+    {
+      path: "/contact/new/",
+      name: "create-contact",
+      component: ContactComponent,
+    },
+    {
+      path: "/contact/link/update/:entityID/:contactID",
+      name: "update-contact",
+      component: ContactComponent,
+    },
+    {
+      path: "/contact/all",
+      name: "get-all-contacts",
+      component: ContactListComponent,
+    },
+    {
+      path: "/contact/single/:contactID",
+      name: "get-single-contact",
+      component: ContactComponent,
+    },
+    {
+      path: "/checkin/:entityId",
+      name: "checkin",
+      component: CheckInRedirect,
+    },
+    {
+      path: "/settings/account",
+      name: "account-manager",
+      component: AccountManagerComponent,
+    },
+    {
+      path: "*",
+      redirect: "/login",
+    },
+  ],
+  scrollBehavior() {
+    return { x: 0, y: 0 };
+  },
+});

--- a/src/templates/AccountManager.vue
+++ b/src/templates/AccountManager.vue
@@ -1,0 +1,115 @@
+<template>
+  <b-container fluid="md" id="account-manager">
+    <h1>Account Management</h1>
+    <h4 class="text-muted">Add or update account information</h4>
+    <b-row class="mt-4">
+      <b-col cols="12">
+        <b-form @submit.prevent="submitAccountUpdate">
+          <b-form-group id="display-name" label="Name">
+            <b-form-input type="text" required v-model="formValues.name" />
+          </b-form-group>
+          <b-form-group id="user-phone" label="Phone Number">
+            <b-form-input
+              type="tel"
+              v-model="formControl.numberFormatted"
+              @keydown.exact="formatTelInput($event)"
+              @keydown.delete="formatTelBackspace($event)"
+              minlength="10"
+              :state="formControl.phoneValid"
+              aria-describedby="phone-input-live-feedback"
+            />
+            <b-form-invalid-feedback id="phone-input-live-feedback"
+              >Please enter a valid phone number.
+            </b-form-invalid-feedback>
+          </b-form-group>
+          <b-form-group id="user-email" label="Email Address">
+            <b-form-input
+              type="email"
+              v-model="formValues.email"
+              :state="formControl.emailValid"
+              aria-describedby="email-input-live-feedback"
+            />
+            <b-form-invalid-feedback id="email-input-live-feedback"
+              >Please enter a valid email address.
+            </b-form-invalid-feedback>
+          </b-form-group>
+          <b-button type="submit" variant="primary" class="mr-2" @click.prevent="submitForm">
+            Update
+          </b-button>
+          <b-button type="cancel" variant="outline-secondary" @click.prevent="returnToDashboard">
+            Cancel
+          </b-button>
+        </b-form>
+      </b-col>
+    </b-row>
+  </b-container>
+</template>
+
+<script>
+export default {
+  name: "AccountManager",
+  data: () => ({
+    formValues: {
+      displayName: "",
+      email: "",
+      phone: "",
+    },
+    formControl: {
+      phoneValid: null,
+      emailValid: null,
+      numberFormatted: "",
+    },
+  }),
+  mounted() {
+    const email = this.$jwt.decode(this.$root.auth_token).email;
+    this.$root.apiGETRequest(`/user/${email}`, this.handleUserResponse);
+  },
+  methods: {
+    returnToDashboard() {
+      this.$router.push({ name: "dashboard" });
+    },
+    handleUserResponse(response) {
+      this.formValues = {
+        displayName: response.displayName ? response.displayName : "",
+        email: response.email ? response.email : "",
+        phone: response.phone ? response.phone : "",
+      };
+      this.formControl.numberFormatted = response.phone
+        ? this.$options.filters.phone(response.phone)
+        : "";
+    },
+    submitForm() {
+      // Should the name field be required and have a validation for length > 0?
+      // Should there be a confirmation message after successfully updating information
+      // instead of pushing a user back to the dashboard?
+      // Should a user be able to remove their phone number e.g. if phone.length === 0, send null?
+      this.formControl.phoneValid = this.formValues.phone.length >= 10;
+      this.formControl.emailValid =
+        this.formValues.email.includes("@") && this.formValues.email.includes(".");
+      if (this.formControl.phoneValid && this.formControl.emailValid) {
+        const updatedUser = this.formValues;
+        this.$root.apiPUTRequest("/user", updatedUser, this.returnToDashboard);
+      }
+    },
+    formatTelInput(event) {
+      event.preventDefault();
+      if (new RegExp("1|2|3|4|5|6|7|8|9|0").test(event.key)) {
+        if (this.formValues.phone === null) {
+          this.formValues.phone = "";
+        }
+        this.formValues.phone += event.key;
+        this.formControl.numberFormatted = this.$options.filters.phone(this.formValues.phone);
+      }
+    },
+    formatTelBackspace(event) {
+      event.preventDefault();
+      if (this.formValues.phone.length > 0) {
+        this.formValues.phone = this.formValues.phone.slice(0, -1);
+        this.formControl.numberFormatted = this.$options.filters.phone(this.formValues.phone);
+      }
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped></style>


### PR DESCRIPTION
# Description

Account Manager Page added.

Allows end user to update account information such as:

1. Display Name
2. Phone Number
3. Email

## Related PRs

none

## Related Issues

| https://github.com/CodeForBaltimore/Healthcare-Rollcall/issues/99 |
| ---- |

## Todos

- [ ] Tests
- [ ] Documentation

## Impacted Areas in Application

New client-side route added, `/settings/account`, accessible via user dropdown in navigation.

![image](https://user-images.githubusercontent.com/50671267/104138644-58238780-5373-11eb-83a1-f8d5d3e30132.png)

## Questions For Improvements/Requirements:

- What fields should be accessible and editable via account settings? `displayName`, `email`, and `phone` are the main ones I saw via requesting `/user/{email}`.
- Does giving a user the ability to change their email mess up any other related data within the system?
- Should the Display Name be a required field, and if so, should it have validations for a minimum character limit as well as special characters?
- Upon successful submission, user is pushed back to `/dashboard` - should there be a confirmation message instead and allow them to navigate elsewhere on their own?
- Should a user be able to remove their phone number via deleting the contents for the `phone` input and submitting whatever the API's requirement is? (`null` or empty string?)
- Should the URL for accessing this page not be a child route of `/settings` since there is no actual `/settings` page currently?