### PR TITLE
mkdocs.yml and .md files for wiki added

### DIFF
--- a/docs/DevIntro.md
+++ b/docs/DevIntro.md
@@ -1,0 +1,7 @@
+<TODO: Add HCRC specific content to this section>
+
+Wanna improve Healthcare-Rollcall? This page will provide an introduction the to the architecture, implementation and processes of Healthcare-Rollcall.
+
+### Components
+
+This application will be broken down into several components. Each will be outlined here.

--- a/docs/HowToContribute.md
+++ b/docs/HowToContribute.md
@@ -1,0 +1,13 @@
+# Welcome
+
+The CodeForBaltimore team is thrilled that you might be interested in helping us help others! You do not need to be an expert, just willing to help. This page will give you some background on this project with suggestion and advice on how to contribute.
+
+## What is Healthcare-Rollcall?
+
+Healthcare-Rollcall is a web app designed to interact with the [Bmore-Responsive API](https://codeforbaltimore.github.io/Bmore-Responsive/). In the event of a disaster, Baltimore City and the Baltimore City Health Department (BCHD) needs to be able to verify the status of all healthcare providers in the city. Examples include:
+
+- Widespread power blackout
+- Epidemic or Pandemic response (COVID-19)
+- Natural disaster
+
+<TODO: Add HCRC specific content to this section>

--- a/docs/HowToUse.md
+++ b/docs/HowToUse.md
@@ -1,0 +1,101 @@
+# API Spec
+
+<TODO: Review and determine whether the content is appropriate for this section, if content should be moved elsewhere in the wiki, or whether it is context appropriate for HCRC>
+
+The [Bmore-Responsive API](https://codeforbaltimore.github.io/Bmore-Responsive/) is documented via a OAS 3.0 API specification in the file `swagger.json`. This API spec lists all the endpoints, supported REST actions, and the request and response data formats. While you can open the `swagger.json` file in any text editor, there are better ways to view it in a richer format, such as:
+
+- View the [API Spec on Swaggerhub](https://app.swaggerhub.com/apis/codeforbaltimore/bmoreResponsive)
+- If you are running Healthcare-Rollcall with `docker-compose up -d --build`, then you can just point your browser at the root URL of your server, often `http://localhost:3001/`, you'll be redirected to `http://localhost:3001/api-docs/`
+
+## Keeping your API up to date
+
+By default the backend solution will pull the `master` branch of [Bmore-Responsive](https://github.com/CodeForBaltimore/Bmore-Responsive). If you wish to keep this up to date you should run:
+
+```shell
+docker-compose build
+```
+
+You can also specify a tagged release by setting the `API_TAG` value in your `.env` file:
+
+```shell
+API_TAG=1.3.2
+```
+
+For more information on valid `API_TAG` values, see: [docker build - Git repositories](https://docs.docker.com/engine/reference/commandline/build/#git-repositories)
+
+## Compiles and hot-reloads for development
+
+Using `docker-compose` will mount your local `./src` directory into the application, which allows you to continue to make changes and view them within the application.
+
+The application will be available at [http://localhost:3000/](http://localhost:3000/).
+
+**User Credentials:** To find example user credentials, look to the user.json file in the [Bmore-Responsive repository](https://github.com/CodeForBaltimore/Bmore-Responsive).
+
+**Note:** Depending on the OS you are running `Docker` on your localhost may be mapped to a different IP address. The standard IP address `Docker` is mapped to on Windows is `192.168.99.100` so you would access the application at `192.168.99.100:8080`.
+
+## Windows 10 Home hot-reloads
+
+Due to how the installation and setup for Docker works on a Windows 10 Home machine, there are a couple quirks while running a Docker container through the WSL2 subsystem.
+
+The main issue is that hot-reloading doesn't work out-of-the-box. Docker's `inotify` propogation will not trigger a reload for files edited on the host side (Windows 10) while the container is running in the WSL2 subsystem.
+
+The work around is to configure `environment` for **web** in the `docker-compose.yaml`.
+
+```yaml
+version: "3"
+services:
+  web:
+    ...
+    environment:
+      - ${PORT:-3000}
+      - CHOKIDAR_USEPOLLING=true
+      - CHOKIDAR_INTERVAL=1000
+```
+`CHOKIDAR_USEPOLLING=true` reconfigures how webpack watches the file system and will enable hot-reloading, but **this is notably less performant and can be CPU intensive**.  
+Adding `CHOKIDAR_INTERVAL=1000` sets
+a 1 second interval for webpack to check for changes, allowing consistent reloads while increasing the performance of this method drastically.
+
+**Also be sure to remove these additional enironment settings before pushing a branch or merging a PR. This only pertains to Windows 10 Home and should not be part of the default `docker-compose` configuration.**
+
+## Compiles and minifies for production
+
+```shell
+npm run build
+```
+
+## Lints and fixes files
+
+```shell
+npm run lint
+```
+
+## Customize configuration
+
+See [Configuration Reference](https://cli.vuejs.org/config/).
+
+<!-- # Using this product
+
+How would someone use this product? Give a few examples here. -->
+
+## Testing
+
+### Using Jest for unit testing
+
+```shell
+`npm test`
+`yarn test`
+```
+
+### Using Snyk to check for security vulnerabilities
+
+```shell
+`npm install snyk -g`
+`snyk test`
+```
+
+# Sources and Links
+
+We are also building a back-end API to feed and manage data for this project. To view that project, or to contribute to it, please visit the repo here: [https://github.com/CodeForBaltimore/Bmore-Responsive](https://github.com/CodeForBaltimore/Bmore-Responsive)
+<p align="center">
+  <img src="docs/img/CfB.png" width="400">
+</p>

--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -1,0 +1,44 @@
+# Quick Start
+
+This brief guide will get you up and running your own copy of Healthcare-Rollcall locally. The approach below is just one way to get Healthcare-Rollcall running. For other approaches and more detail on configuration, please see the [Slow Start Guide](/SlowStart) section of the Users' Guide.
+
+## Step 1 - Download code from github
+
+We're assuming that you've cloned or downloaded the contents of the [Healthcare-Rollcall repository on GitHub](https://github.com/CodeForBaltimore/Healthcare-Rollcall).
+
+## Step 2 - Install Required Software
+
+In order to follow this quick start guide you'll need to make sure you have the following software installed on your machine:
+
+- **Docker Desktop with DockerHub access** - Docker is not technically required to run BMore Responsive, but this guide uses Docker to get up and running quickly. You can confirm that you have Docker Desktop by executing `docker -v` at a command line. If your machine replies with a version number like `Docker version 19.03.8, build afaca4b` then you have Docker Desktop installed. If you need to install Docker Desktop, head on over to the [Docker Desktop page](https://www.docker.com/products/docker-desktop).
+
+**If you are on a Windows 10 Home machine:**  
+While Windows 10 Pro, Education, and Enterprise allow easy installation and usage of Docker, Windows 10 Home requires an alternate installation method. Reference Docker's docs for [ Windows 10 Home Installation](https://docs.docker.com/docker-for-windows/install-windows-home/).
+
+Additional notes regarding Windows 10 Home and Docker can be found in the [Users Guide](HowToUse.md).
+
+## Step 3 - Configure Your Environment
+
+Create a file in the root directory of your project called `.env` and add the following to it:
+
+```conf
+PORT=3000
+VUE_APP_BASE_API_URL=http://localhost:3001
+DATABASE_PASSWORD= # Custom value
+JWT_KEY= # Custom value
+```
+
+- `PORT`: The port the web service will be exposed on the host machine. Default: 3000
+- `VUE_APP_BASE_API_URL`: The URL to the api service, includes hostname and port. Default: http://localhost:3001.
+- `DATABASE_PASSWORD`: The password used to authenticate to the postgres database. For security, use a custom value.
+- `JWT_KEY`: A secret value to generate JSON Web Tokens (JWTs) locally. For security, use a custom value.
+
+## Step 4 - Run Development Stack
+
+To run the application run `docker-compose up -d --build`.
+
+## Step 5 - Confirm Success
+
+To confirm the application is running, just point your browser to [http://localhost:3000](http://localhost:3000). You should see the login screen.
+
+**Congratulations!** Why not check out the ["How to Use"](HowToUse.md) guide and learn more by using Bmore Responsive. When done, you can shut everything down with `docker-compose down`.

--- a/docs/SlowStart.md
+++ b/docs/SlowStart.md
@@ -1,0 +1,27 @@
+# Slow Start
+
+<TODO: Review and determine whether content is context appropriate for HCRC>
+
+If you want to tweak the installation of Healthcare-Rollcall or have a different environment, then this page will provide additional detail on how to install/configure Healthcare-Rollcall.
+
+## Configuring via Environment variables
+
+Regardless of where you are running the system, environment variables are required to run this application. These variables are set in the `.env` file on the root directory of Healthcare-Rollcall.
+
+## Deploying to AWS
+
+If you want to deploy to AWS, we have included a `terraform` option. For more information on how to use this feature, please see the README in `/terraform`.
+
+<TODO: Consider migrating terraform docs to be here or do some sort of INCLUDE to reuse the content>
+
+## Running in Docker
+
+You can build and run the application in Docker locally by running the following commands:
+
+```shell
+docker-compose up -d
+```
+
+### docker-compose
+
+To use the `docker-compose.yml` file included you will first need to set [environment variables](#environment-variables). It is not recommended to use `docker-compose` for any reason other than to test a solution for a separate front-end component.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,29 @@
+# Healthcare-Rollcall Wiki Home
+
+## What is Healthcare-Rollcall?
+
+Healthcare-Rollcall is a web app built on top of the [Bmore-Responsive API](https://codeforbaltimore.github.io/Bmore-Responsive/). In the event of a disaster, Baltimore City and the Baltimore City Health Department (BCHD) needs to be able to verify the status of all healthcare providers in the city.
+
+## What does it do?
+
+This system will provide methods for healthcare providers to check-in during disasters, and update their information during non-emergency periods. During an emergency this system will track providers responses to a questionnaire. This questionnaire can be specific to a single disaster, or can be more general. Examples:
+
+- Widespread power blackout
+- Epidemic or Pandemic response (COVID-19)
+- Natural disaster
+
+This system will make use of digital services and modern methodologies to automate parts of the check-in process to help the city prioritize its call list and response plan. Additionally, the system will validate contact information regularly during non-emergency times to ensure the city has the most up-to-date information for each provider.
+
+## How do I use it?
+
+You can begin using Healthcare-Rollcall in minutes by following our the steps in the [Quick Start Guide](QuickStart.md). If you have more advanced installation/configuration needs take a look at out [Slow Start Guide](SlowStart.md).
+
+Once you've installed the app, check out the [How To Use Guide](HowToUse.md) to understand the use the API with the Healthcare-Rollcall client application.
+
+## How is it built? Can I contribute?
+
+Healthcare-Rollcall is an Open Source project developed mostly in Vue.js. You are welcome to fork the repo to customize for your own needs, but we'd welcome contributions to improve Healthcare-Rollcall directly.
+
+For more technical detail on the solution and guidance on contributing, please see our [Developers' Guide](DevIntro.md).
+
+Maintained by [CodeForBaltimore](https://codeforbaltimore.org/) and supported by [CodeForAmerica](https://codeforamerica.org/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,17 @@
+site_name: Healthcare-Rolecall Wiki
+
+nav:
+  - 'Home': 'index.md'
+  - 'For Users': 
+    - 'Quick Start - Less than 10 min': 'QuickStart.md'
+    - 'Slow Start - Advanced Config': 'SlowStart.md'
+    - 'Users Guide': 'HowToUse.md'
+  - 'For Developers':
+    - 'Solution Overview': 'DevIntro.md'
+  - 'For Everyone':
+    - 'How to Contribute': 'HowToContribute.md'
+    - 'Code of Conduct': 'Code_of_Conduct.md'
+
+theme:
+  name: readthedocs
+  


### PR DESCRIPTION
# Description

Wiki pages made with `mkdocs` and added to project directory, mimicking Bmore-Responsive wiki structure. Additional information related to Windows 10 Home and Docker included.

If approved, closes #227 and closes #239.

## Related PRs

N/A

## Related Issues

List related Issues:

| https://github.com/CodeForBaltimore/Healthcare-Rollcall/issues/227 |
| ---- |
|  https://github.com/CodeForBaltimore/Healthcare-Rollcall/issues/239  |

## Todos

- [ ] Review content of `.md` files and adjust accordingly for context of HCRC.
- [ ] Any related configuration to deploy or link to as HCRC Wiki on Github repository.

## Impacted Areas in Application

- `mkdocs.yml` added to project root and wiki page `.md` files added to `/docs`.
