### PR TITLE
Nmarklund10/274 issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,15 @@ In the event of a disaster, Baltimore City and the Baltimore City Health Departm
   - [What is this?](#what-is-this)
   - [Documentation](#documentation)
 - [Project setup](#project-setup)
-  - [Docker and docker-compose](#docker-and-docker-compose)
-    - [Full .env example](#full-env-example)
-    - [Keeping your API up to date](#keeping-your-api-up-to-date)
+  - [Keeping your API up to date](#keeping-your-api-up-to-date)
   - [Compiles and hot-reloads for development](#compiles-and-hot-reloads-for-development)
   - [Compiles and minifies for production](#compiles-and-minifies-for-production)
   - [Lints and fixes files](#lints-and-fixes-files)
   - [Customize configuration](#customize-configuration)
 - [Using this product](#using-this-product)
   - [Testing](#testing)
+    - [Using Jest for unit testing](#using-jest-for-unit-testing)
+    - [Using Snyk to check for security vulnerabilities](#using-snyk-to-check-for-security-vulnerabilities)
 - [Sources and Links](#sources-and-links)
   - [Contributors ✨](#contributors-)
 
@@ -47,6 +47,7 @@ Add the following to a file named `.env` in your project directory:
 ```conf
 PORT=3000
 VUE_APP_BASE_API_URL=http://localhost:3001
+VUE_APP_API_VERSION=1
 DATABASE_PASSWORD= # Custom value
 JWT_KEY= # Custom value
 ```

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,7 +69,9 @@ export default {
     const user = this.$root.auth_token
         ? this.$jwt.decode(this.$root.auth_token).email
         : false;
-    const role = this.$jwt.decode(this.$root.auth_token).type || '';
+    const role = this.$root.auth_token
+        ? this.$jwt.decode(this.$root.auth_token).type
+        : '';
     return {
       user,
       navBar,

--- a/src/components/Facility.vue
+++ b/src/components/Facility.vue
@@ -85,7 +85,7 @@
                 >{{ contact.contact.name }}</router-link>
                 <p v-if="contact.contact.phone && contact.contact.phone[0]">
                   Phone:
-                  <a v-bind:href="'tel:' + contact.contact.phone[0].number">{{ contact.contact.phone[0].number | phone }}</a> 
+                  <a v-bind:href="'tel:' + contact.contact.phone[0].number">{{ contact.contact.phone[0].number | phone }}</a>
                 </p>
                 <p v-if="contact.contact.email && contact.contact.email[0]">
                     Email:
@@ -617,14 +617,14 @@ export default {
       this.entity.checkIn.checkIns.push(this.newCheckIn);
       this.entityCheckIn.checkIn = this.newCheckIn;
       this.$root.apiPUTRequest(
-        "/entity",
+        "entity",
         this.entityCheckIn,
         this.setLastCheckInData
       );
     },
     getEntity() {
       this.$root.apiGETRequest(
-        "/entity/" + this.$route.params.entityID,
+        "entity/" + this.$route.params.entityID,
         this.updateFacilityData
       );
     },

--- a/src/components/covidForm.vue
+++ b/src/components/covidForm.vue
@@ -437,7 +437,7 @@ export default {
       this.showForm = false;
       this.newCheckIn.date = new Date();
       this.entityCheckIn.checkIn = this.newCheckIn;
-      this.$root.apiPUTRequest("/entity", this.entityCheckIn, function() {
+      this.$root.apiPUTRequest("entity", this.entityCheckIn, function() {
         self.updateParent();
       });
       const token = this.$jwt.decode(this.$root.auth_token);

--- a/src/components/quickForm.vue
+++ b/src/components/quickForm.vue
@@ -205,7 +205,7 @@ export default {
       this.showForm = false;
       this.newCheckIn.date = new Date();
       this.entityCheckIn.checkIn = this.newCheckIn;
-      this.$root.apiPUTRequest("/entity", this.entityCheckIn, function() {
+      this.$root.apiPUTRequest("entity", this.entityCheckIn, function() {
         self.updateParent();
       });
       const token = this.$jwt.decode(this.$root.auth_token)

--- a/src/components/vaccForm.vue
+++ b/src/components/vaccForm.vue
@@ -86,7 +86,7 @@
             name="question-2b-radio"
             value="Not Applicable"
           >Not Applicable</b-form-radio>
-      </b-form-group> 
+      </b-form-group>
     <h6>Part C</h6>
       <b-form-group
         id="check-in-input-question-2c"
@@ -387,7 +387,7 @@ export default {
       this.showForm = false;
       this.newCheckIn.date = new Date();
       this.entityCheckIn.checkIn = this.newCheckIn;
-      this.$root.apiPUTRequest("/entity", this.entityCheckIn, function() {
+      this.$root.apiPUTRequest("entity", this.entityCheckIn, function() {
         self.updateParent();
       });
       const token = this.$jwt.decode(this.$root.auth_token);

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 import App from './App.vue'
 import router from './router'
 import store from './store'
+import { api } from './utils/api'
 import {BootstrapVue, BootstrapVueIcons} from 'bootstrap-vue'
 import VueCookies from 'vue-cookies'
 import vueCountryRegionSelect from 'vue-country-region-select'
@@ -126,7 +127,7 @@ new Vue({
     }),
     data() {
         return {
-            api: process.env.VUE_APP_BASE_API_URL,
+            api: api,
             authenticated: false
         }
     },
@@ -172,9 +173,10 @@ new Vue({
             this.$cookies.remove('Health_Auth')
         },
         apiGETRequest(endpoint, callback) {
+            const fullUrl = new URL(endpoint, api)
             let self = this
             axios
-                .get(self.api + endpoint, {
+                .get(fullUrl.toString(), {
                     headers: {
                         'token': self.getSavedToken()
                     },
@@ -187,9 +189,10 @@ new Vue({
                 })
         },
         apiPUTRequest(endpoint, payload, callback) {
+            const fullUrl = new URL(endpoint, api)
             let self = this
             axios
-                .put(self.api + endpoint, payload, {
+                .put(fullUrl.toString(), payload, {
                     headers: {
                         'token': self.getSavedToken()
                     },
@@ -202,9 +205,10 @@ new Vue({
                 })
         },
         apiPOSTRequest(endpoint, payload, callback) {
+            const fullUrl = new URL(endpoint, api)
             let self = this
             axios
-                .post(self.api + endpoint, payload, {
+                .post(fullUrl.toString(), payload, {
                     headers: {
                         'token': self.getSavedToken()
                     },
@@ -218,10 +222,11 @@ new Vue({
                 })
         },
         apiDELRequest(endpoint, callback) {
+            const fullUrl = new URL(endpoint, api)
             let self = this
             // requirement for axios
             axios
-                .delete(self.api + endpoint, {
+                .delete(fullUrl.toString(), {
                     headers: {
                         'token': self.getSavedToken()
                     },

--- a/src/templates/Contact.vue
+++ b/src/templates/Contact.vue
@@ -195,7 +195,7 @@ export default {
       this.populateEntitiesDropdown();
     },
     getContact(id) {
-      this.$root.apiGETRequest("/contact/" + id, this.updateContact);
+      this.$root.apiGETRequest("contact/" + id, this.updateContact);
     },
     populateEntitiesDropdown() {
       for (let entity_ of this.contact.entities) {
@@ -222,7 +222,7 @@ export default {
       }
     },
     getAllContacts() {
-      this.$root.apiGETRequest("/contact/", this.populateContactsDropdown);
+      this.$root.apiGETRequest("contact/", this.populateContactsDropdown);
     },
     returnToLastPage() {
       if (this.$route.name === "get-single-contact" || this.$route.name === "create-contact") {
@@ -263,9 +263,9 @@ export default {
           newContact.attributes = null;
         }
         if (this.$route.params.contactID) {
-          this.$root.apiPUTRequest("/contact", newContact, this.returnToLastPage);
+          this.$root.apiPUTRequest("contact", newContact, this.returnToLastPage);
         } else {
-          this.$root.apiPOSTRequest("/contact", newContact, this.returnToLastPage);
+          this.$root.apiPOSTRequest("contact", newContact, this.returnToLastPage);
         }
       }
     },
@@ -274,7 +274,7 @@ export default {
         contacts: [{ id: this.selectedContact.id, title: this.selectedContact.relationshipTitle }],
       };
       this.$root.apiPOSTRequest(
-        "/entity/link/" + this.$route.params.entityID,
+        "entity/link/" + this.$route.params.entityID,
         body,
         this.returnToLastPage
       );
@@ -288,7 +288,7 @@ export default {
         contacts: [{ id: this.$route.params.contactID }],
       };
       this.$root.apiPOSTRequest(
-        "/entity/unlink/" + this.selectedEntityID,
+        "entity/unlink/" + this.selectedEntityID,
         body,
         this.returnToLastPage
       );
@@ -299,7 +299,7 @@ export default {
         return;
       }
       this.$root.apiDELRequest(
-        "/contact/" + this.$route.params.contactID,
+        "contact/" + this.$route.params.contactID,
         {},
         this.returnToLastPage
       );

--- a/src/templates/ContactList.vue
+++ b/src/templates/ContactList.vue
@@ -33,7 +33,7 @@
             <router-link :to="{ name: 'create-contact' }">
               <b-button v-if="showAdmin">Create Contact</b-button>
             </router-link>
-            
+
             <b-button v-if="showAdmin" v-on:click="downloadCSV()" class="ml-1">Download CSV</b-button>
           </b-col>
         </b-row>
@@ -132,7 +132,7 @@ export default {
   },
   methods: {
     getContacts() {
-      this.$root.apiGETRequest("/contact/", this.handleContactsResponse);
+      this.$root.apiGETRequest("contact/", this.handleContactsResponse);
     },
     handleContactsResponse(response) {
       this.contacts = response.results;
@@ -143,7 +143,7 @@ export default {
     },
     sendEmail() {
       // send emails
-      this.$root.apiPOSTRequest(`/contact/send/contact/${this.actionedContact.id}`, {}, this.handleSendResponse)
+      this.$root.apiPOSTRequest(`contact/send/contact/${this.actionedContact.id}`, {}, this.handleSendResponse)
       // close modal
       this.$nextTick(() => {
         this.showEmailErr = false;
@@ -161,7 +161,7 @@ export default {
       })
     },
     downloadCSV() {
-      const path = this.filter.keyword ? `/csv/Contact?filter=${this.filter.keyword}` : '/csv/Contact';
+      const path = this.filter.keyword ? `csv/Contact?filter=${this.filter.keyword}` : 'csv/Contact';
       this.$root.apiGETRequest(path, this.createDownload)
     },
     createDownload(data) {

--- a/src/templates/Dashboard.vue
+++ b/src/templates/Dashboard.vue
@@ -41,13 +41,13 @@
             <b-button v-if="showAdmin" v-on:click="addFacility()">Create Facility</b-button>
             <b-button v-if="showAdmin" class="ml-1" v-on:click="downloadCSV()">Download CSV</b-button>
             <b-button v-if="showAdmin || showUser" @click="actionedFacility = null" class="ml-1" v-b-modal.email-facility-modal>
-              Email 
+              Email
               {{ selectedEntityIds.length ? 'Selected' : '' }}
               Facilities
             </b-button>
           </b-col>
           <div>
-            <b-modal id="email-facility-modal" title="Send Emails to Facilities" ok-title="Send" @ok="sendEmails">              
+            <b-modal id="email-facility-modal" title="Send Emails to Facilities" ok-title="Send" @ok="sendEmails">
               <div v-if="selectedEntityIds.length || actionedFacility">
                 Are you sure you want to send an email to the contacts of the following facilities?
                 <ul>
@@ -73,7 +73,7 @@
           </div>
         </b-row>
         <b-table
-            ref="entityTable" 
+            ref="entityTable"
             id="dashboard-table"
             striped
             hover
@@ -122,7 +122,7 @@
               name="selectEntityAll"
               v-bind:value='true'
               v-model='selectAllEntities'
-              id="selectEntityAll" 
+              id="selectEntityAll"
               @change="selectEntityAllClick"
             >
               <span class='sr-only'>
@@ -257,7 +257,7 @@ export default {
         payload.entityType = this.facilityTypeSelected !== FACILITY_TYPE_ALL ? this.facilityTypeSelected : null;
       }
 
-      this.$root.apiPOSTRequest("/contact/send", payload, this.handleSendEmailsResponse)
+      this.$root.apiPOSTRequest("contact/send", payload, this.handleSendEmailsResponse)
       // close modal
       this.$nextTick(() => {
         // Reset selected Entities
@@ -311,7 +311,7 @@ export default {
       this.selectAllEntities = checkedValue.length === this.entities.length
     },
     downloadCSV() {
-      const path = this.filter.keyword ? `/csv/Entity?filter=${this.filter.keyword}` : '/csv/Entity';
+      const path = this.filter.keyword ? `csv/Entity?filter=${this.filter.keyword}` : 'csv/Entity';
       this.$root.apiGETRequest(path, this.createDownload)
     },
     createDownload(data) {
@@ -331,7 +331,7 @@ export default {
       return {value: status, text: status, disabled: false}
     })
     this.statusOptions = [{value: null, text: "All"}, ...options]
-    this.$root.apiGETRequest("/entity", this.updateEntities)
+    this.$root.apiGETRequest("entity", this.updateEntities)
   },
 }
 </script>

--- a/src/templates/Facility.vue
+++ b/src/templates/Facility.vue
@@ -324,7 +324,7 @@ export default {
       }
     },
     getEntity() {
-      this.$root.apiGETRequest("/entity/" + this.$route.params.entityID, this.updateFacilityData);
+      this.$root.apiGETRequest("entity/" + this.$route.params.entityID, this.updateFacilityData);
     },
     duplicateData(object) {
       return JSON.parse(JSON.stringify(object));

--- a/src/templates/FacilityEdit.vue
+++ b/src/templates/FacilityEdit.vue
@@ -132,7 +132,7 @@ export default {
       this.populateContactsDropdown();
     },
     getEntity(id) {
-      this.$root.apiGETRequest("/entity/" + id, this.updateEntity);
+      this.$root.apiGETRequest("entity/" + id, this.updateEntity);
     },
     populateContactsDropdown() {
       for (let contact_ of this.entity.contacts) {
@@ -161,9 +161,9 @@ export default {
       let newEntity = this.duplicateData(this.entity);
 
       if (this.$route.params.entityID) {
-        this.$root.apiPUTRequest("/entity", newEntity, this.returnToLastPage);
+        this.$root.apiPUTRequest("entity", newEntity, this.returnToLastPage);
       } else {
-        this.$root.apiPOSTRequest("/entity", newEntity, this.returnToLastPage);
+        this.$root.apiPOSTRequest("entity", newEntity, this.returnToLastPage);
       }
     },
     duplicateData(object) {
@@ -178,7 +178,7 @@ export default {
         entities: [{ id: this.$route.params.entityID }],
       };
       this.$root.apiPOSTRequest(
-        "/contact/unlink/" + this.selectedContactID,
+        "contact/unlink/" + this.selectedContactID,
         body,
         this.returnToLastPage
       );
@@ -189,7 +189,7 @@ export default {
         return;
       }
       this.$root.apiDELRequest(
-        "/entity/" + this.$route.params.entityID,
+        "entity/" + this.$route.params.entityID,
         this.$router.push({
           name: "dashboard",
         })

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,7 +1,9 @@
 import axios from 'axios'
 
+export const api = `${process.env.VUE_APP_BASE_API_URL}/v${process.env.VUE_APP_API_VERSION}/`
+
 export const postLogin = async (email, password) => {
-  const fullUrl = new URL('/user/login', process.env.VUE_APP_BASE_API_URL)
+  const fullUrl = new URL('user/login', api)
   let response
   try {
     response = await axios.post(
@@ -36,7 +38,7 @@ export const postLogin = async (email, password) => {
 }
 
 export const postReset = (email) => {
-  const fullUrl = new URL('/user/reset/' + email, process.env.VUE_APP_BASE_API_URL)
+  const fullUrl = new URL('user/reset/' + email, api)
   return axios.post(fullUrl.toString(),
     {
       email
@@ -44,7 +46,7 @@ export const postReset = (email) => {
 }
 
 export const updateUser = (email_token, email, password) => {
-  const fullUrl = new URL('/user', process.env.VUE_APP_BASE_API_URL)
+  const fullUrl = new URL('user', api)
   return axios.put(fullUrl.toString(),
     {
       email,


### PR DESCRIPTION
# Description

The main feature of this branch is to have the frontend use the prepend v1 to its calls to the API.  I did this with the `URL` object and incorporated that functionality into the App's `apiGETRequest`, etc. commands instead of relying on string concatenation.  I also made this one variable exported from `utils.js`, and the version is configurable with environment variable `VUE_APP_API_VERSION`.   On an unrelated note, I fixed an error that was showing in the console in the `App.vue` file.  There was code that was trying to do null-coalescing with the || operator, but the JWT decode error would still show in the console, so I used a ternary operator instead.

## Related PRs

List related PRs against other branches:

| branch          | PR       |
| --------------- | -------- |
| Add v1 prefix to routes (API server)| [#](https://github.com/CodeForBaltimore/Bmore-Responsive/issues/406) |

## Deploy Notes

Merge this at same time as related PR above

You must run this using the docker image built off https://github.com/nmarklund10/Bmore-Responsive/tree/nmarklund10/issue-406